### PR TITLE
Replace json gem with multi_json

### DIFF
--- a/lib/malachite.rb
+++ b/lib/malachite.rb
@@ -1,7 +1,7 @@
 require 'malachite/version'
 fail "Malachite #{Malachite::VERSION} does not support Ruby < 2.0.0" if RUBY_VERSION < '2.0.0'
 
-require 'json'
+require 'multi_json'
 require 'fiddle'
 require 'active_support/all'
 
@@ -38,11 +38,11 @@ module Malachite
   end
 
   def self.load_json(string)
-    JSON.parse(string)
+    MultiJson.load(string)
   end
 
   def self.dump_json(object)
-    JSON.generate(object)
+    MultiJson.dump(object)
   end
 end
 

--- a/malachite.gemspec
+++ b/malachite.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.version       = Malachite::VERSION
 
   spec.required_ruby_version = '>= 2.0.0'
-  spec.add_dependency 'json', '~> 1.0'
+  spec.add_dependency 'multi_json', '~> 1.0'
   spec.add_development_dependency 'bundler', '~> 1.9'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5'


### PR DESCRIPTION
Rather than depend on a single JSON gem, no reason it can't be swappable via multi_json. I use Oj in production for example instead of json or yajl.
